### PR TITLE
modify README.md because of file names error and new branch A

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ git clone https://github.com/yomyom1234/VisionSpace visionspace
 2. unity hub 실행
 3. mediapipe 실행
 ```
-cd visionspace/Asset/Script
+cd visionspace/Assets/Scripts
 python MediapipePython.py
 ```
 4. 유니티 프로젝트 실행


### PR DESCRIPTION
readme에 적힌 
cd visionspace/Asset/Script
cd visionspace/Assets/Scripts로 바꿨습니다.

새로운 branch를 A라고 하고 거기에 lp판 디자인을 넣었습니다.